### PR TITLE
trails: working with One-to-Many Models

### DIFF
--- a/AddresssDao.java
+++ b/AddresssDao.java
@@ -17,9 +17,6 @@ import de.hybris.platform.cuppytrail.model.UserrModel;
 import java.util.List;
 
 
-/**
- *
- */
 public interface AddresssDao
 {
 	void registerAddress(AddresssModel address);

--- a/AddresssDao.java
+++ b/AddresssDao.java
@@ -1,0 +1,32 @@
+/*
+ * [y] hybris Platform
+ *
+ * Copyright (c) 2000-2016 SAP SE
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of SAP
+ * Hybris ("Confidential Information"). You shall not disclose such
+ * Confidential Information and shall use it only in accordance with the
+ * terms of the license agreement you entered into with SAP Hybris.
+ */
+package de.hybris.platform.cuppytrail.daos;
+
+import de.hybris.platform.cuppytrail.model.AddresssModel;
+import de.hybris.platform.cuppytrail.model.UserrModel;
+
+import java.util.List;
+
+
+/**
+ *
+ */
+public interface AddresssDao
+{
+	void registerAddress(AddresssModel address);
+
+	List<AddresssModel> findAllAddresses();
+
+	void addAddressesToUser(UserrModel user, AddresssModel... address);
+
+	List<AddresssModel> findAddressesByKewword(String keyword);
+}

--- a/DefaultAddresssDao.java
+++ b/DefaultAddresssDao.java
@@ -27,7 +27,6 @@ public class DefaultAddresssDao extends DefaultGenericDao<AddresssModel> impleme
 	public void registerAddress(final AddresssModel address)
 	{
 		modelService.save(address);
-
 	}
 
 	@Override
@@ -39,8 +38,6 @@ public class DefaultAddresssDao extends DefaultGenericDao<AddresssModel> impleme
 	@Override
 	public List<AddresssModel> findAddressesByKewword(final String keyword)
 	{
-		//		final StringBuilder sb = new StringBuilder();
-
 		final String s = "SELECT DISTINCT {" + AddresssModel.PK + "} " + "FROM {" + AddresssModel._TYPECODE + "} "
 				+ "WHERE CONCAT ({" + AddresssModel.CITY + "}, {" + AddresssModel.STREET + "}) LIKE '%" + keyword + "%'";
 

--- a/DefaultAddresssDao.java
+++ b/DefaultAddresssDao.java
@@ -39,16 +39,12 @@ public class DefaultAddresssDao extends DefaultGenericDao<AddresssModel> impleme
 	@Override
 	public List<AddresssModel> findAddressesByKewword(final String keyword)
 	{
-		final StringBuilder sb = new StringBuilder();
+		//		final StringBuilder sb = new StringBuilder();
 
-		//		sb.append("SELECT {").append(UserrModel.PK).append("} ");
-		//		sb.append("FROM {").append(UserrModel._TYPECODE).append("} ");
-		//		sb.append("WHERE {").append(AddresssModel.CITY).append("} ");
-		//		sb.append("LIKE CONCAT('%', CONCAT(?keyword, '%')) ");
-		//		sb.append("{").append(AddresssModel.STREET).append("} ");
-		//		sb.append("LIKE CONCAT('%', CONCAT(?keyword, '%')) ");
+		final String s = "SELECT DISTINCT {" + AddresssModel.PK + "} " + "FROM {" + AddresssModel._TYPECODE + "} "
+				+ "WHERE CONCAT ({" + AddresssModel.CITY + "}, {" + AddresssModel.STREET + "}) LIKE '%" + keyword + "%'";
 
-		final FlexibleSearchQuery query = new FlexibleSearchQuery(sb.toString());
+		final FlexibleSearchQuery query = new FlexibleSearchQuery(s);
 
 		query.addQueryParameter("keyword", keyword);
 
@@ -58,7 +54,14 @@ public class DefaultAddresssDao extends DefaultGenericDao<AddresssModel> impleme
 	@Override
 	public void addAddressesToUser(final UserrModel user, final AddresssModel... addresses)
 	{
-		user.getAddresses().addAll(Arrays.asList(addresses));
+		if (user.getAddresses() == null)
+		{
+			user.setAddresses(Arrays.asList(addresses));
+		}
+		else
+		{
+			user.getAddresses().addAll(Arrays.asList(addresses));
+		}
 
 		modelService.save(user);
 	}

--- a/DefaultAddresssDao.java
+++ b/DefaultAddresssDao.java
@@ -2,7 +2,6 @@ package de.hybris.platform.cuppytrail.daos.impl;
 
 import de.hybris.platform.cuppytrail.daos.AddresssDao;
 import de.hybris.platform.cuppytrail.model.AddresssModel;
-import de.hybris.platform.cuppytrail.model.PersonnModel;
 import de.hybris.platform.cuppytrail.model.UserrModel;
 import de.hybris.platform.servicelayer.internal.dao.DefaultGenericDao;
 import de.hybris.platform.servicelayer.model.ModelService;
@@ -42,12 +41,12 @@ public class DefaultAddresssDao extends DefaultGenericDao<AddresssModel> impleme
 	{
 		final StringBuilder sb = new StringBuilder();
 
-		sb.append("SELECT {").append(PersonnModel.PK).append("} ");
-		sb.append("FROM {").append(PersonnModel._TYPECODE).append("} ");
-		sb.append("WHERE {").append(AddresssModel.CITY).append("} ");
-		sb.append("LIKE CONCAT('%', CONCAT(?keyword, '%')) ");
-		sb.append("{").append(AddresssModel.STREET).append("} ");
-		sb.append("LIKE CONCAT('%', CONCAT(?keyword, '%')) ");
+		//		sb.append("SELECT {").append(UserrModel.PK).append("} ");
+		//		sb.append("FROM {").append(UserrModel._TYPECODE).append("} ");
+		//		sb.append("WHERE {").append(AddresssModel.CITY).append("} ");
+		//		sb.append("LIKE CONCAT('%', CONCAT(?keyword, '%')) ");
+		//		sb.append("{").append(AddresssModel.STREET).append("} ");
+		//		sb.append("LIKE CONCAT('%', CONCAT(?keyword, '%')) ");
 
 		final FlexibleSearchQuery query = new FlexibleSearchQuery(sb.toString());
 

--- a/DefaultAddresssDao.java
+++ b/DefaultAddresssDao.java
@@ -1,0 +1,66 @@
+package de.hybris.platform.cuppytrail.daos.impl;
+
+import de.hybris.platform.cuppytrail.daos.AddresssDao;
+import de.hybris.platform.cuppytrail.model.AddresssModel;
+import de.hybris.platform.cuppytrail.model.PersonnModel;
+import de.hybris.platform.cuppytrail.model.UserrModel;
+import de.hybris.platform.servicelayer.internal.dao.DefaultGenericDao;
+import de.hybris.platform.servicelayer.model.ModelService;
+import de.hybris.platform.servicelayer.search.FlexibleSearchQuery;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.annotation.Resource;
+
+
+public class DefaultAddresssDao extends DefaultGenericDao<AddresssModel> implements AddresssDao
+{
+	@Resource
+	private ModelService modelService;
+
+	public DefaultAddresssDao()
+	{
+		super(AddresssModel._TYPECODE);
+	}
+
+	@Override
+	public void registerAddress(final AddresssModel address)
+	{
+		modelService.save(address);
+
+	}
+
+	@Override
+	public List<AddresssModel> findAllAddresses()
+	{
+		return find();
+	}
+
+	@Override
+	public List<AddresssModel> findAddressesByKewword(final String keyword)
+	{
+		final StringBuilder sb = new StringBuilder();
+
+		sb.append("SELECT {").append(PersonnModel.PK).append("} ");
+		sb.append("FROM {").append(PersonnModel._TYPECODE).append("} ");
+		sb.append("WHERE {").append(AddresssModel.CITY).append("} ");
+		sb.append("LIKE CONCAT('%', CONCAT(?keyword, '%')) ");
+		sb.append("{").append(AddresssModel.STREET).append("} ");
+		sb.append("LIKE CONCAT('%', CONCAT(?keyword, '%')) ");
+
+		final FlexibleSearchQuery query = new FlexibleSearchQuery(sb.toString());
+
+		query.addQueryParameter("keyword", keyword);
+
+		return getFlexibleSearchService().<AddresssModel> search(query).getResult();
+	}
+
+	@Override
+	public void addAddressesToUser(final UserrModel user, final AddresssModel... addresses)
+	{
+		user.getAddresses().addAll(Arrays.asList(addresses));
+
+		modelService.save(user);
+	}
+}

--- a/DefaultAddresssDaoIntegrationTest.java
+++ b/DefaultAddresssDaoIntegrationTest.java
@@ -1,14 +1,3 @@
-/*
- * [y] hybris Platform
- *
- * Copyright (c) 2000-2016 SAP SE
- * All rights reserved.
- *
- * This software is the confidential and proprietary information of SAP
- * Hybris ("Confidential Information"). You shall not disclose such
- * Confidential Information and shall use it only in accordance with the
- * terms of the license agreement you entered into with SAP Hybris.
- */
 package de.hybris.platform.cuppytrail.daos.impl;
 
 import static org.junit.Assert.assertEquals;
@@ -31,7 +20,6 @@ import org.junit.Test;
 
 public class DefaultAddresssDaoIntegrationTest extends ServicelayerTransactionalTest
 {
-
 	@Resource
 	private AddresssDao addresssDao;
 	@Resource

--- a/DefaultAddresssDaoIntegrationTest.java
+++ b/DefaultAddresssDaoIntegrationTest.java
@@ -1,0 +1,124 @@
+/*
+ * [y] hybris Platform
+ *
+ * Copyright (c) 2000-2016 SAP SE
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of SAP
+ * Hybris ("Confidential Information"). You shall not disclose such
+ * Confidential Information and shall use it only in accordance with the
+ * terms of the license agreement you entered into with SAP Hybris.
+ */
+package de.hybris.platform.cuppytrail.daos.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import de.hybris.platform.cuppytrail.daos.AddresssDao;
+import de.hybris.platform.cuppytrail.model.AddresssModel;
+import de.hybris.platform.cuppytrail.model.UserrModel;
+import de.hybris.platform.servicelayer.ServicelayerTransactionalTest;
+import de.hybris.platform.servicelayer.model.ModelService;
+
+import java.util.Date;
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import jersey.repackaged.com.google.common.collect.Lists;
+
+import org.junit.Test;
+
+
+public class DefaultAddresssDaoIntegrationTest extends ServicelayerTransactionalTest
+{
+
+	@Resource
+	private AddresssDao addresssDao;
+	@Resource
+	private ModelService modelService;
+
+	@Test
+	public void findAddressByKeywordInTheCity()
+	{
+		addresssDao.registerAddress(newAddress(1, "Veliko Tarnovo", "8 Ivan Vazov str."));
+		addresssDao.registerAddress(newAddress(2, "Draganovo", "20 Petar Ignatov str."));
+
+		final List<AddresssModel> addresses = addresssDao.findAddressesByKewword("ovo");
+
+		assertEquals(2, addresses.size());
+		assertEquals(Integer.valueOf(1), addresses.get(0).getCode());
+		assertEquals(Integer.valueOf(2), addresses.get(1).getCode());
+	}
+
+	@Test
+	public void findAddressByKeywordInTheStreet()
+	{
+		addresssDao.registerAddress(newAddress(1, "Sofia", "8 Dimitar Vazov str."));
+		addresssDao.registerAddress(newAddress(2, "Sofia", "20 Petar Ignatov str."));
+		addresssDao.registerAddress(newAddress(3, "Sofia", "20 Dimo Dimov str."));
+
+		final List<AddresssModel> addresses = addresssDao.findAddressesByKewword("tar");
+
+		assertEquals(2, addresses.size());
+		assertEquals(Integer.valueOf(1), addresses.get(0).getCode());
+		assertEquals(Integer.valueOf(2), addresses.get(1).getCode());
+	}
+
+	@Test
+	public void addAddressesToUserWitoutAnyAddresses()
+	{
+		final AddresssModel firstAddress = newAddress(1, "Sofia", "8 Dimitar Vazov str.");
+		final AddresssModel secondAddress = newAddress(2, "Sofia", "20 Petar Ignatov str.");
+
+		final UserrModel user = newUser("email@test.com", "name", new Date());
+
+		addresssDao.addAddressesToUser(user, firstAddress, secondAddress);
+
+		final List<AddresssModel> addresses = addresssDao.findAllAddresses();
+
+		assertEquals(2, addresses.size());
+		assertEquals(user, addresses.get(0).getUser());
+		assertEquals(user, addresses.get(1).getUser());
+	}
+
+	@Test
+	public void addAddressesToUserWithAddresses()
+	{
+		final AddresssModel firstAddress = newAddress(1, "Sofia", "8 Dimitar Vazov str.");
+		final AddresssModel secondAddress = newAddress(2, "Sofia", "20 Petar Ignatov str.");
+
+		final UserrModel user = newUser("email@test.com", "name", new Date());
+		user.setAddresses(Lists.newArrayList(firstAddress));
+
+		addresssDao.addAddressesToUser(user, secondAddress);
+
+		final List<AddresssModel> addresses = addresssDao.findAllAddresses();
+
+		assertEquals(2, addresses.size());
+		assertEquals(user, addresses.get(0).getUser());
+		assertEquals(user, addresses.get(1).getUser());
+	}
+
+
+	private AddresssModel newAddress(final int i, final String city, final String street)
+	{
+		final AddresssModel address = modelService.create(AddresssModel.class);
+
+		address.setCode(Integer.valueOf(i));
+		address.setCity(city);
+		address.setStreet(street);
+
+		return address;
+	}
+
+	private UserrModel newUser(final String email, final String name, final Date birthDay)
+	{
+		final UserrModel user = modelService.create(UserrModel.class);
+
+		user.setEmail(email);
+		user.setName(name);
+		user.setBirthDay(birthDay);
+
+		return user;
+	}
+}

--- a/DefaultUserrDao.java
+++ b/DefaultUserrDao.java
@@ -1,0 +1,66 @@
+/*
+ * [y] hybris Platform
+ *
+ * Copyright (c) 2000-2016 SAP SE
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of SAP
+ * Hybris ("Confidential Information"). You shall not disclose such
+ * Confidential Information and shall use it only in accordance with the
+ * terms of the license agreement you entered into with SAP Hybris.
+ */
+package de.hybris.platform.cuppytrail.daos.impl;
+
+import de.hybris.platform.cuppytrail.daos.UserrDao;
+import de.hybris.platform.cuppytrail.model.UserrModel;
+import de.hybris.platform.servicelayer.internal.dao.DefaultGenericDao;
+import de.hybris.platform.servicelayer.model.ModelService;
+import de.hybris.platform.servicelayer.search.FlexibleSearchQuery;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+
+public class DefaultUserrDao extends DefaultGenericDao<UserrModel> implements UserrDao
+{
+	@Resource
+	private ModelService modelService;
+
+	public DefaultUserrDao()
+	{
+		super(UserrModel._TYPECODE);
+	}
+
+
+	@Override
+	public void registerUser(final UserrModel user)
+	{
+		modelService.save(user);
+	}
+
+	@Override
+	public List<UserrModel> findAllUsers()
+	{
+		return find();
+	}
+
+	@Override
+	public List<UserrModel> findAllUsersOnSameStreet()
+	{
+		// YTODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public List<UserrModel> findAllUsersWithoutAddress()
+	{
+		final String s = "SELECT {Userr.PK} " + "FROM {Userr} " + "WHERE {Userr.PK} NOT IN ({{ " + "SELECT {Userr.PK} "
+				+ "FROM {Addresss JOIN Userr ON {Addresss.user}={Userr.PK}} }})";
+
+		final FlexibleSearchQuery query = new FlexibleSearchQuery(s);
+
+		return getFlexibleSearchService().<UserrModel> search(query).getResult();
+
+	}
+}

--- a/DefaultUserrDao.java
+++ b/DefaultUserrDao.java
@@ -1,14 +1,3 @@
-/*
- * [y] hybris Platform
- *
- * Copyright (c) 2000-2016 SAP SE
- * All rights reserved.
- *
- * This software is the confidential and proprietary information of SAP
- * Hybris ("Confidential Information"). You shall not disclose such
- * Confidential Information and shall use it only in accordance with the
- * terms of the license agreement you entered into with SAP Hybris.
- */
 package de.hybris.platform.cuppytrail.daos.impl;
 
 import de.hybris.platform.cuppytrail.daos.UserrDao;
@@ -31,7 +20,6 @@ public class DefaultUserrDao extends DefaultGenericDao<UserrModel> implements Us
 	{
 		super(UserrModel._TYPECODE);
 	}
-
 
 	@Override
 	public void registerUser(final UserrModel user)

--- a/DefaultUserrDaoIntegrationTest.java
+++ b/DefaultUserrDaoIntegrationTest.java
@@ -1,14 +1,3 @@
-/*
- * [y] hybris Platform
- *
- * Copyright (c) 2000-2016 SAP SE
- * All rights reserved.
- *
- * This software is the confidential and proprietary information of SAP
- * Hybris ("Confidential Information"). You shall not disclose such
- * Confidential Information and shall use it only in accordance with the
- * terms of the license agreement you entered into with SAP Hybris.
- */
 package de.hybris.platform.cuppytrail.daos.impl;
 
 import static org.junit.Assert.assertEquals;

--- a/DefaultUserrDaoIntegrationTest.java
+++ b/DefaultUserrDaoIntegrationTest.java
@@ -1,0 +1,87 @@
+/*
+ * [y] hybris Platform
+ *
+ * Copyright (c) 2000-2016 SAP SE
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of SAP
+ * Hybris ("Confidential Information"). You shall not disclose such
+ * Confidential Information and shall use it only in accordance with the
+ * terms of the license agreement you entered into with SAP Hybris.
+ */
+package de.hybris.platform.cuppytrail.daos.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import de.hybris.platform.cuppytrail.daos.UserrDao;
+import de.hybris.platform.cuppytrail.model.AddresssModel;
+import de.hybris.platform.cuppytrail.model.UserrModel;
+import de.hybris.platform.servicelayer.ServicelayerTransactionalTest;
+import de.hybris.platform.servicelayer.model.ModelService;
+
+import java.util.Date;
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import jersey.repackaged.com.google.common.collect.Lists;
+
+import org.junit.Test;
+
+
+public class DefaultUserrDaoIntegrationTest extends ServicelayerTransactionalTest
+{
+	@Resource
+	private UserrDao userrDao;
+	@Resource
+	private ModelService modelService;
+
+	@Test
+	public void registerUser()
+	{
+		final UserrModel user = newUser("email@test.com", "Ivan Petrov", new Date());
+		userrDao.registerUser(user);
+
+		final List<UserrModel> users = userrDao.findAllUsers();
+
+		assertEquals(1, users.size());
+		assertEquals("email@test.com", users.get(0).getEmail());
+	}
+
+	@Test
+	public void findUsersWithoutAddresses()
+	{
+		final UserrModel user = newUser("email@test.com", "Ivan Petrov", new Date());
+		user.setAddresses(Lists.newArrayList(newAddress(123)));
+
+		final UserrModel userWithoutAddress = newUser("email2@test.com", "Pavel Martinov", new Date());
+
+		userrDao.registerUser(user);
+		userrDao.registerUser(userWithoutAddress);
+
+		final List<UserrModel> users = userrDao.findAllUsersWithoutAddress();
+
+		assertEquals(1, users.size());
+		assertEquals("email2@test.com", users.get(0).getEmail());
+	}
+
+	//HELPER METHODS
+	private UserrModel newUser(final String email, final String name, final Date birthDay)
+	{
+		final UserrModel user = modelService.create(UserrModel.class);
+
+		user.setEmail(email);
+		user.setName(name);
+		user.setBirthDay(birthDay);
+
+		return user;
+	}
+
+	private AddresssModel newAddress(final int code)
+	{
+		final AddresssModel address = modelService.create(AddresssModel.class);
+		address.setCode(Integer.valueOf(code));
+
+		return address;
+	}
+}

--- a/UserrDao.java
+++ b/UserrDao.java
@@ -1,0 +1,31 @@
+/*
+ * [y] hybris Platform
+ *
+ * Copyright (c) 2000-2016 SAP SE
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of SAP
+ * Hybris ("Confidential Information"). You shall not disclose such
+ * Confidential Information and shall use it only in accordance with the
+ * terms of the license agreement you entered into with SAP Hybris.
+ */
+package de.hybris.platform.cuppytrail.daos;
+
+import de.hybris.platform.cuppytrail.model.UserrModel;
+
+import java.util.List;
+
+
+/**
+ *
+ */
+public interface UserrDao
+{
+	void registerUser(UserrModel user);
+
+	List<UserrModel> findAllUsers();
+
+	List<UserrModel> findAllUsersOnSameStreet();
+
+	List<UserrModel> findAllUsersWithoutAddress();
+}

--- a/UserrDao.java
+++ b/UserrDao.java
@@ -1,14 +1,3 @@
-/*
- * [y] hybris Platform
- *
- * Copyright (c) 2000-2016 SAP SE
- * All rights reserved.
- *
- * This software is the confidential and proprietary information of SAP
- * Hybris ("Confidential Information"). You shall not disclose such
- * Confidential Information and shall use it only in accordance with the
- * terms of the license agreement you entered into with SAP Hybris.
- */
 package de.hybris.platform.cuppytrail.daos;
 
 import de.hybris.platform.cuppytrail.model.UserrModel;
@@ -16,9 +5,6 @@ import de.hybris.platform.cuppytrail.model.UserrModel;
 import java.util.List;
 
 
-/**
- *
- */
 public interface UserrDao
 {
 	void registerUser(UserrModel user);

--- a/cuppytrail-items.xml
+++ b/cuppytrail-items.xml
@@ -1,0 +1,67 @@
+
+		<enumtype code="AddressType" dynamic="false">
+			<value code="permanent" />
+			<value code="residential" />
+			<value code="shipping" />
+		</enumtype>
+
+
+		<relation code="UserAddressRelation" localized="false">
+			<sourceElement type="Userr" qualifier="user" cardinality="one" />
+			<targetElement type="Addresss" qualifier="addresses" cardinality="many" />
+		</relation>
+
+
+		<itemtype code="Userr">
+			<deployment table="CuppyTrailUserr" typecode="19991" />
+			<attributes>
+
+				<attribute type="java.lang.String" qualifier="email">
+					<persistence type="property" />
+					<modifiers unique="true" optional="false" />
+				</attribute>
+
+				<attribute type="java.lang.String" qualifier="name">
+					<persistence type="property" />
+				</attribute>
+
+				<attribute type="java.util.Date" qualifier="birthDay">
+					<persistence type="property" />
+				</attribute>
+
+			</attributes>
+		</itemtype>
+
+
+		<itemtype code="Addresss">
+			<deployment table="CuppyTrailAddresss" typecode="19995" />
+			<attributes>
+
+				<attribute type="java.lang.Integer" qualifier="code">
+					<persistence type="property" />
+					<modifiers unique="true" optional="false" />
+				</attribute>
+
+				<attribute type="java.lang.String" qualifier="country">
+					<persistence type="property" />
+				</attribute>
+
+				<attribute type="java.lang.String" qualifier="city">
+					<persistence type="property" />
+				</attribute>
+
+				<attribute type="java.lang.String" qualifier="street">
+					<persistence type="property" />
+				</attribute>
+
+				<attribute type="java.lang.Integer" qualifier="zipCode">
+					<persistence type="property" />
+				</attribute>
+
+				<attribute type="AddressType" qualifier="addressType">
+					<persistence type="property" />
+					<defaultvalue>em().getEnumerationValue("AddressType","permanent")</defaultvalue>
+				</attribute>
+
+			</attributes>
+		</itemtype>

--- a/hmc.xml
+++ b/hmc.xml
@@ -1,0 +1,90 @@
+	<explorertree>
+		<group name="cuppytrailgroup">
+			<typeref type="Addresss" />
+			<typeref type="Userr" />
+		</group>
+	</explorertree>
+
+	<type name="Userr" mode="append">
+		<organizer>
+			<search mode="replace">
+				<condition attribute="email" />
+				<condition attribute="name" />
+				<condition attribute="birthDay" />
+				<condition attribute="addresses" />
+			</search>
+			<result>
+				<listview mode="replace">
+					<itemlayout>
+						<attribute name="email" />
+						<attribute name="name" />
+						<attribute name="birthDay" />
+						<attribute name="addresses" />
+					</itemlayout>
+				</listview>
+			</result>
+			<editor>
+				<essentials>
+					<listlayout>
+						<attribute name="email" />
+					</listlayout>
+				</essentials>
+				<tab name="tab.cuppytrail">
+					<section name="section.cuppytrail">
+						<listlayout>
+							<attribute name="name" />
+							<attribute name="birthDay" />
+							<attribute name="addresses" />
+						</listlayout>
+					</section>
+				</tab>
+			</editor>
+		</organizer>
+	</type>
+
+	<type name="Addresss" mode="append">
+		<organizer>
+			<search mode="replace">
+				<condition attribute="code" />
+				<condition attribute="city" />
+				<condition attribute="country" />
+				<condition attribute="street" />
+				<condition attribute="zipCode" />
+				<condition attribute="addressType" />
+				<condition attribute="user" />
+			</search>
+			<result>
+				<listview mode="replace">
+					<itemlayout>
+						<attribute name="code" />
+						<attribute name="city" />
+						<attribute name="country" />
+						<attribute name="street" />
+						<attribute name="zipCode" />
+						<attribute name="addressType" />
+						<attribute name="user" />
+					</itemlayout>
+				</listview>
+			</result>
+			<editor>
+				<essentials>
+					<listlayout>
+						<attribute name="email" />
+					</listlayout>
+				</essentials>
+				<tab name="tab.cuppytrail">
+					<section name="section.cuppytrail">
+						<listlayout>
+							<attribute name="code" />
+							<attribute name="city" />
+							<attribute name="country" />
+							<attribute name="street" />
+							<attribute name="zipCode" />
+							<attribute name="addressType" />
+							<attribute name="user" />
+						</listlayout>
+					</section>
+				</tab>
+			</editor>
+		</organizer>
+	</type>

--- a/projectdataUserAddress.impex
+++ b/projectdataUserAddress.impex
@@ -1,0 +1,7 @@
+INSERT_UPDATE Userr; 		email[unique=true]; 		name;		birthDay[dateformat=dd.MM.yyyy]
+; 									"email1@mail.com";		"Ivan";	22.10.1985
+;									"email2@gmail.com";		"Peter";	3.1.1985;
+
+INSERT_UPDATE Addresss;		code[unique=true];		country;		city; 	street;				zipCode;	addressType(code);	user(email)			
+;									1;								Bulgaria;	Varna;	Ivan Vazov 5;		9000;		shipping;				email1@mail.com
+;									2;								Bulgaria;	Sofia;	Hristo Botev 2;	1000;		permanent;				email1@mail.com


### PR DESCRIPTION
Created `Userr` and `Addresss` itemtypes. One user can have many addresses for different purposes like `permanent` `residential` and `shipping` address.

Purpose is to do different CRUD operations on the Models and understand `one-to-many` relations. 
Second is to understand the `impEx` syntax for working with such models.

Address UI in HMC:
![addresshmcview](https://cloud.githubusercontent.com/assets/8696264/19604283/405ee714-97bd-11e6-9893-eb5c78ce8ba6.jpg)

User UI in HMC:
![userhmcview](https://cloud.githubusercontent.com/assets/8696264/19604295/4d6e63e4-97bd-11e6-82a7-a0df022379ef.jpg)
